### PR TITLE
Little change in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Speedtest by Ookla installer script
 
 1. `curl -Lo speedtest-installer.sh https://raw.githubusercontent.com/AlwaysRik/speedtest-installer/main/speedtest-installer.sh`
-  (if u get a error like curl not found or something else, try: `apt install curl -y` and try again)
 
 2. `chmod u+x speedtest-installer.sh && sed -i -e 's/\r$//' speedtest-installer.sh`
 


### PR DESCRIPTION
Removed the error notice; sudo apt-get install curl -y already exists in the script.